### PR TITLE
0.8.3 - Updated types schema to include new project and fix arch

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.github.redhatqe/polarize "0.8.2-SNAPSHOT"
+(defproject com.github.redhatqe/polarize "0.8.3-SNAPSHOT"
   :description "Polarion related stuff for RHSM TestNG."
   :url "https://github.com/RedHatQE/polarize"
   :java-source-path "src"

--- a/src/main/resources/schema/types.xsd
+++ b/src/main/resources/schema/types.xsd
@@ -22,6 +22,7 @@ elementFormDefault="qualified">
         <xs:restriction base="xs:string">
             <xs:enumeration value="RHEL6"/>
             <xs:enumeration value="RedHatEnterpriseLinux7"/>
+            <xs:enumeration value="RHELSS"/>
             <xs:enumeration value="PLATTP"/>
         </xs:restriction>
     </xs:simpleType>
@@ -76,7 +77,7 @@ elementFormDefault="qualified">
 
     <xs:simpleType name="arch-types">
         <xs:restriction base="xs:string">
-            <xs:enumeration value="x8664"/>
+            <xs:enumeration value="x86_64"/>
             <xs:enumeration value="ppc64"/>
             <xs:enumeration value="ppc64le"/>
             <xs:enumeration value="ia64"/>


### PR DESCRIPTION
We are currently able to submit jobs to the new project, even though this isn't set here - updating it anyway just in case.
Polarion also has changed the arch value from x8664, so updating here as well.