### PR TITLE
CCT-623: Change x86_64 arch type back to x8664 for reasons

### DIFF
--- a/src/main/resources/schema/types.xsd
+++ b/src/main/resources/schema/types.xsd
@@ -77,7 +77,7 @@ elementFormDefault="qualified">
 
     <xs:simpleType name="arch-types">
         <xs:restriction base="xs:string">
-            <xs:enumeration value="x86_64"/>
+            <xs:enumeration value="x8664"/>
             <xs:enumeration value="ppc64"/>
             <xs:enumeration value="ppc64le"/>
             <xs:enumeration value="ia64"/>


### PR DESCRIPTION
Need to ensure polarized reports allow submission of x8664 due to reporting requirements.